### PR TITLE
Add Pagination to all Users, Groups, Forms, FormEntries

### DIFF
--- a/erp/settings.py
+++ b/erp/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'home.apps.HomeConfig',
     'user_management.apps.UserManagementConfig',
     'forms.apps.FormsConfig',
+    'bootstrap_pagination'
 ]
 
 MIDDLEWARE = [

--- a/forms/templates/forms/workflow_entries/index.html
+++ b/forms/templates/forms/workflow_entries/index.html
@@ -1,6 +1,8 @@
 {% extends "forms/app_base.html" %}
 
 {% block content %}
+{% load bootstrap_pagination %}
+
 <div class="row">
     <div class="col-md-12 page-header">
         <h2>Responses to {{ workflow.name }}</h2>
@@ -35,6 +37,10 @@
             {% endfor %}
             </tbody>
         </table>
+
+        <div class="text-center">
+            {% bootstrap_paginate responses %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/forms/templates/forms/workflows/index.html
+++ b/forms/templates/forms/workflows/index.html
@@ -2,6 +2,8 @@
 
 {% block content %}
 {% load form_extras %}
+{% load bootstrap_pagination %}
+
 <div class="row">
     <div class="col-md-12 page-header">
         <h2>Forms</h2>
@@ -40,6 +42,10 @@
     {% endfor %}
     </tbody>
     </table>
+
+    <div class="text-center">
+        {% bootstrap_paginate workflows %}
+    </div>
     </div>
 </div>
 {% endblock %}

--- a/forms/views/workflow.py
+++ b/forms/views/workflow.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from forms.models import Workflow
 from forms.forms import WorkflowForm
@@ -7,7 +8,17 @@ from forms.forms import WorkflowForm
 
 @login_required
 def workflow_index(request):
-    return render(request, 'forms/workflows/index.html', {'workflows': Workflow.objects.all()})
+    workflow_list = Workflow.objects.all()
+    page = request.GET.get('page')
+    paginator = Paginator(workflow_list, 10)
+    try:
+        workflows = paginator.page(page)
+    except PageNotAnInteger:
+        workflows = paginator.page(1)
+    except EmptyPage:
+        workflows = paginator.page(paginator.num_pages)
+
+    return render(request, 'forms/workflows/index.html', {'workflows': workflows})
 
 
 @login_required

--- a/forms/views/workflow_entry.py
+++ b/forms/views/workflow_entry.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from forms.models import WorkflowEntry, Workflow
 
@@ -8,7 +9,17 @@ from forms.models import WorkflowEntry, Workflow
 def workflow_entry_index(request, workflow_id):
     workflow = get_object_or_404(Workflow, pk=workflow_id)
     form_elements = workflow.formelement_set.all()
-    responses = workflow.workflowentry_set.all()
+
+    response_list = workflow.workflowentry_set.all()
+    page = request.GET.get('page')
+    paginator = Paginator(response_list, 10)
+    try:
+        responses = paginator.page(page)
+    except PageNotAnInteger:
+        responses = paginator.page(1)
+    except EmptyPage:
+        responses = paginator.page(paginator.num_pages)
+
     context = {'workflow': workflow, 'form_elements': form_elements, "responses": responses}
     return render(request, 'forms/workflow_entries/index.html', context)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==1.10.3
 django-positions==0.5.4
+django-bootstrap-pagination==1.6.2

--- a/user_management/templates/user_management/groups/index.html
+++ b/user_management/templates/user_management/groups/index.html
@@ -1,6 +1,7 @@
 {% extends "user_management/app_base.html" %}
 
 {% block content %}
+{% load bootstrap_pagination %}
 
 <div class="row">
     <div class="col-md-12 page-header">
@@ -38,6 +39,10 @@
             {% endfor %}
             </tbody>
         </table>
+
+        <div class="text-center">
+            {% bootstrap_paginate groups %}
+        </div>
     </div>
 </div>
 

--- a/user_management/templates/user_management/groups/show.html
+++ b/user_management/templates/user_management/groups/show.html
@@ -1,6 +1,7 @@
 {% extends "user_management/app_base.html" %}
 
 {% block content %}
+{% load bootstrap_pagination %}
 
 <div class="row">
     <div class="col-md-12 page-header">
@@ -32,7 +33,7 @@
 
 <div class="row">
     <div class="page-header col-md-12">
-        <h3>List of all users in the group ({{ users.count }})</h3>
+        <h3>List of all users in the group</h3>
     </div>
 
     <div class="col-md-12">
@@ -64,6 +65,10 @@
             {% endfor %}
             </tbody>
         </table>
+
+        <div class="text-center">
+            {% bootstrap_paginate users %}
+        </div>
     </div>
 </div>
 

--- a/user_management/templates/user_management/users/index.html
+++ b/user_management/templates/user_management/users/index.html
@@ -1,6 +1,8 @@
 {% extends "user_management/app_base.html" %}
 
 {% block content %}
+{% load bootstrap_pagination %}
+
 <div class="row">
     <div class="col-md-12 page-header">
         <h2>Users</h2>
@@ -41,6 +43,10 @@
             {% endfor %}
             </tbody>
         </table>
+
+        <div class="text-center">
+            {% bootstrap_paginate users %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/user_management/views/group.py
+++ b/user_management/views/group.py
@@ -2,13 +2,23 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 from django.contrib.auth.models import Group, User
 from django.contrib.auth.decorators import login_required
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from user_management.forms import GroupForm
 
 
 @login_required
 def group_index(request):
-    groups = Group.objects.all()
+    group_list = Group.objects.all()
+    page = request.GET.get('page')
+    paginator = Paginator(group_list, 10)
+    try:
+        groups = paginator.page(page)
+    except PageNotAnInteger:
+        groups = paginator.page(1)
+    except EmptyPage:
+        groups = paginator.page(paginator.num_pages)
+
     return render(request, 'user_management/groups/index.html', {'groups': groups})
 
 
@@ -31,7 +41,16 @@ def group_new(request):
 @login_required
 def group_show(request, group_id):
     group = get_object_or_404(Group, id=group_id)
-    users = group.user_set.all()
+    user_list = group.user_set.all()
+    page = request.GET.get('page')
+    paginator = Paginator(user_list, 10)
+    try:
+        users = paginator.page(page)
+    except PageNotAnInteger:
+        users = paginator.page(1)
+    except EmptyPage:
+        users = paginator.page(paginator.num_pages)
+
     context = {
             'users': users,
             'group': group

--- a/user_management/views/user.py
+++ b/user_management/views/user.py
@@ -2,13 +2,23 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from user_management.forms import RegisterUserForm, EditUserForm
 
 
 @login_required
 def user_index(request):
-    users = User.objects.all()
+    user_list = User.objects.all()
+    page = request.GET.get('page')
+    paginator = Paginator(user_list, 10)
+    try:
+        users = paginator.page(page)
+    except PageNotAnInteger:
+        users = paginator.page(1)
+    except EmptyPage:
+        users = paginator.page(paginator.num_pages)
+
     return render(request, 'user_management/users/index.html', {'users': users})
 
 


### PR DESCRIPTION
- Per page is limit is 10 and is hardcoded for now.
- I've used https://github.com/jmcclell/django-bootstrap-pagination for  adding the pagination links
- I've added pagination to User#index, Group#index, Form/Workflow#index, FormEntry#index and Group#show to paginate the users in a group

Solves #76 